### PR TITLE
Update TiktokSdkV2Plugin.swift

### DIFF
--- a/ios/Classes/TiktokSdkV2Plugin.swift
+++ b/ios/Classes/TiktokSdkV2Plugin.swift
@@ -5,7 +5,7 @@ import TikTokOpenSDKCore
 
 public class TiktokSdkV2Plugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "com.tofinds/tiktok_sdk_v2", binaryMessenger: registrar.messenger())
+    let channel = FlutterMethodChannel(name: "com.tofinds.tiktok_sdk_v2", binaryMessenger: registrar.messenger())
     let instance = TiktokSdkV2Plugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
     registrar.addApplicationDelegate(instance)


### PR DESCRIPTION
There is a spelling error in the name, which causes iOS to have a method chanel not found exception.